### PR TITLE
Bamboo version bump to v8.2.8 and K8s manifest default tag set to v2023.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL version="8.2.7"
 LABEL "uk.co.saidsef.bamboo"="${REF}"
 
 ENV BAMBOO_HOME /data
-ENV BB_PKG_NAME atlassian-bamboo-${BAMBOO_VERSION:-8.1.7}
+ENV BB_PKG_NAME atlassian-bamboo-${BAMBOO_VERSION:-8.2.8}
 ENV PATH /opt/$BB_PKG_NAME/bin:$PATH
 ENV HOME /tmp
 ENV PORT ${PORT:-8085}

--- a/deployment/kustomization.yml
+++ b/deployment/kustomization.yml
@@ -9,4 +9,4 @@ resources:
 images:
 - name: bamboo
   newName: docker.io/saidsef/atlassian-bamboo-cicd
-  newTag: v2023.02
+  newTag: v2023.04

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -23,7 +23,7 @@ spec:
         app: bamboo
     spec:
       containers:
-        - image: docker.io/saidsef/atlassian-bamboo-cicd:v2023.02
+        - image: docker.io/saidsef/atlassian-bamboo-cicd:v2023.04
           imagePullPolicy: Always
           env:
             - name: HOST_IP


### PR DESCRIPTION
This version allows us to take advantage of new features since v8.1.7 and security fixes
