### PR TITLE
Bump base image to eclipse-temurin:21-jdk-jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM docker.io/eclipse-temurin:11-jdk-jammy
+FROM docker.io/eclipse-temurin:21-jdk-jammy
 
 ARG BUILD_ID=""
-ARG BAMBOO_VERSION="9.4.2"
+ARG BAMBOO_VERSION="12.1.8"
 ARG PORT=""
 ARG REF=""
 
 LABEL org.opencontainers.image.description="Containerised Atlassian Bamboo Server"
 LABEL org.opencontainers.image.authors="Said Sef <said@saidsef.co.uk> (saidsef.co.uk/)"
 LABEL org.opencontainers.image.version="uk.co.saidsef.bamboo=${REF}"
-LABEL org.opencontainers.image.documentation="https://confluence.atlassian.com/bambooreleases/bamboo-9-4-release-notes-1312161836.html"
+LABEL org.opencontainers.image.documentation="https://confluence.atlassian.com/bambooreleases/bamboo-12-1-release-notes-1698955303.html"
 
 ENV BAMBOO_HOME /data
 ENV BB_PKG_NAME atlassian-bamboo-${BAMBOO_VERSION}


### PR DESCRIPTION
Bamboo 12.1.8 supports Java 21 - update base image from `eclipse-temurin:11-jdk-jammy` to `eclipse-temurin:21-jdk-jammy`.